### PR TITLE
Added "compose" to docker_compose_cmd if docker_command_path is speci…

### DIFF
--- a/core/testcontainers/compose/compose.py
+++ b/core/testcontainers/compose/compose.py
@@ -242,7 +242,7 @@ class DockerCompose:
 
     @cached_property
     def compose_command_property(self) -> list[str]:
-        docker_compose_cmd = [self.docker_command_path] if self.docker_command_path else ["docker", "compose"]
+        docker_compose_cmd = [self.docker_command_path, "compose"] if self.docker_command_path else ["docker", "compose"]
         if self.compose_file_name:
             for file in self.compose_file_name:
                 docker_compose_cmd += ["-f", file]


### PR DESCRIPTION
…fied

In an attempt to use podman, the compose_command_property does not call 'compose' correctly if only specified a command path. This fix ensures that 'compose' is called correctly if a specific binary path is specified.